### PR TITLE
fix: correct Unkown→Unknown typo in SMTP error message (mail/smtp.go)

### DIFF
--- a/mail/smtp.go
+++ b/mail/smtp.go
@@ -461,7 +461,7 @@ func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
 		case "Password:":
 			return []byte(a.password), nil
 		default:
-			return nil, errors.New("Unkown fromServer")
+			return nil, errors.New("Unknown fromServer")
 		}
 	}
 	return nil, nil


### PR DESCRIPTION
## Summary
Fixes: `errors.New("Unkown fromServer")` → `errors.New("Unknown fromServer")` in `mail/smtp.go` line 464.

## Details
- **File**: `mail/smtp.go`
- **Line**: 464
- **Change**: Unkown → Unknown
- **Context**: SMTP client initialization error message (user-facing)
- **1 file, 1 line change**

## Verification
```go
return nil, errors.New("Unknown fromServer")
```

This is a user-facing error returned when SMTP server configuration is invalid.